### PR TITLE
Support redmine 4 / rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-gem 'sunspot_rails', '2.2.6'
+gem 'sunspot_rails', '2.5.0'
 gem 'will_paginate', '~> 3.1.3'
 
 group :development do

--- a/app/helpers/redsun_search_helper.rb
+++ b/app/helpers/redsun_search_helper.rb
@@ -5,8 +5,8 @@ module RedsunSearchHelper
   end
   
   def selected_attr_for(facet, val)
-    if params[:search_form] && params[:search_form][facet.to_sym]
-      "selected" if val.to_s.in?(params[:search_form][facet.to_sym]) 
+    if @search_params && @search_params[facet.to_sym]
+      "selected" if val.to_s.in?(@search_params[facet.to_sym])
     end
   end
 

--- a/app/views/redsun_search/_class_name_facet.html.erb
+++ b/app/views/redsun_search/_class_name_facet.html.erb
@@ -4,20 +4,20 @@
       <% count_all = @search.facet(:class_name).rows.map(&:count).sum %>
       <% if count_all > 0 %>
         <%= link_to t("redsun.facet.reset_object_facet", count: number_with_delimiter(count_all)), 
-                    url_for(search_form: {facet.to_sym => ""}.reverse_merge(params[:search_form]) ),
-                    class: params[:search_form][facet.to_sym].blank? ? "selected" : "" %>
+                    url_for(search_form: {:class_name => ""}.reverse_merge(@search_params) ),
+                    class: @search_params[:class_name].blank? ? "selected" : "" %>
       <% end %>
     </li>
-    <% results.facet(facet.to_sym).rows.each do |result| %>
-      <% if result.count > 0 || facet.in?(params[:search_form][:class_name]) %>
+    <% results.facet(:class_name).rows.each do |result| %>
+      <% if result.count > 0 || facet.in?(@search_params[:class_name]) %>
         <li>
           <% if @project.present?
-            url =  redsun_project_search_path(@project, search_form: { class_name: [result.value] }.reverse_merge(params[:search_form]))
+            url =  redsun_project_search_path(@project, search_form: { class_name: [result.value] }.reverse_merge(@search_params))
           else
-            url =  url_for(search_form: { class_name: [result.value]}.reverse_merge(params[:search_form]))
+            url =  url_for(search_form: { class_name: [result.value]}.reverse_merge(@search_params))
           end %>
             <%= link_to "#{t('redsun.facets.values.' + result.value.to_s.downcase.tr(" ", "_"), default: result.value)} (#{number_with_delimiter(result.count, delimiter: '.')})",
-           url, class: result.value.in?(params[:search_form][:class_name]) ? 'selected' : ''
+           url, class: result.value.in?(@search_params[:class_name]) ? 'selected' : ''
             %>
         </li>
       <% end %>

--- a/app/views/redsun_search/_date_facet.html.erb
+++ b/app/views/redsun_search/_date_facet.html.erb
@@ -1,10 +1,10 @@
-<% if results.facet(facet).present? && results.facet(facet).rows && results.facet(facet).rows.count > 1 || params[:search_form][facet].present? %>
+<% if results.facet(facet).present? && results.facet(facet).rows && results.facet(facet).rows.count > 1 || @search_params[facet].present? %>
   <h3><%=t "redsun.facet.#{facet.to_sym}"%></h3>
   <% if search2_enabled? %>
-    <select data-cleared-url="<%=url_for(:search_form => { facet.to_sym => "" }.reverse_merge(params[:search_form]))%>" class="redsun-select2-single" size="1" data-placeholder="<%=t("redsun.placeholder.#{facet}", default: "Select a value!")%>">
+    <select data-cleared-url="<%=url_for(:search_form => { facet.to_sym => "" }.reverse_merge(@search_params))%>" class="redsun-select2-single" size="1" data-placeholder="<%=t("redsun.placeholder.#{facet}", default: "Select a value!")%>">
       <option></option>
       <% results.facet(facet.to_sym).rows.each do |result| %>
-          <option <%=selected_attr_for(facet, result.value) %> value="<%=url_for(:search_form => {facet.to_sym => result.value}.reverse_merge(params[:search_form]))%>">
+          <option <%=selected_attr_for(facet, result.value) %> value="<%=url_for(:search_form => {facet.to_sym => result.value}.reverse_merge(@search_params))%>">
             <% label = t("redsun.facet.date_range_rows.#{result.value}") %>
             <%= (label.present? ? label : "unknown" ) + " (#{result.count})"%>
           </option>
@@ -19,15 +19,15 @@
         </style>
       <ul class="facets">
         <% results.facet(facet.to_sym).rows.each do |result| %>
-          <% if params[:search_form][facet].blank? || params[:search_form].present? && params[:search_form][facet].present? && params[:search_form][facet] == result.value  %>
+          <% if @search_params[facet].blank? || @search_params.present? && @search_params[facet].present? && @search_params[facet] == result.value  %>
             <li>
               <% label = t("redsun.facet.date_range_rows.#{result.value}") %>
               <%= link_to((label.present? ? label : "unknown" ) + " (#{result.count})",
-              url_for(:controller => "redsun_search", :action => :index, :search_form => {facet.to_sym => result.value}.reverse_merge(params[:search_form])))
+              url_for(:controller => "redsun_search", :action => :index, :search_form => {facet.to_sym => result.value}.reverse_merge(@search_params)))
               %>
               <%= link_to t("facet.remove"),
-              url_for(:controller => "redsun_search", :action => :index, :search_form => { facet.to_sym => "" }.reverse_merge(params[:search_form])),
-              :class => "remove" if params[:search_form][facet].present?  %>
+              url_for(:controller => "redsun_search", :action => :index, :search_form => { facet.to_sym => "" }.reverse_merge(@search_params)),
+              :class => "remove" if @search_params[facet].present?  %>
             </li>
           <% end %>
       <% end -%>

--- a/app/views/redsun_search/_facet.html.erb
+++ b/app/views/redsun_search/_facet.html.erb
@@ -1,10 +1,10 @@
 <% if results.facet(facet).present? &&
       results.facet(facet).rows &&
       results.facet(facet).rows.count > 1 &&
-      results.facet(facet).rows.sum(&:count) > 0 || params[:search_form][facet].present? %>
+      results.facet(facet).rows.sum(&:count) > 0 || @search_params[facet].present? %>
 
   <h3 class='redsun-sidebar'><%= t("redsun.facet.#{facet}")%></h3>
-  <% params[:search_form][facet] ||= [] %>
+  <% @search_params[facet] ||= [] %>
  
   <% if search2_enabled? %>
     <select multiple size="5" class="redsun-select2" data-placeholder="<%=t("redsun.placeholder.#{facet}", default: "Select a value!")%>">
@@ -17,10 +17,10 @@
           else
             label = "#{result.value} (#{number_with_delimiter(result.count, delimiter: '.')})"
           end %>
-          <% if result.value.to_s.in?(params[:search_form][facet]) %>
-            <option value='<%= result.value%>' data-facet-url='<%= url_for(search_form: { facet => (params[:search_form][facet] - [result.value.to_s])}.reverse_merge(params[:search_form])) %>' selected><%= label %></option>
+          <% if result.value.to_s.in?(@search_params[facet]) %>
+            <option value='<%= result.value%>' data-facet-url='<%= url_for(search_form: { facet => (@search_params[facet] - [result.value.to_s])}.reverse_merge(@search_params)) %>' selected><%= label %></option>
           <% else %>
-            <option data-facet-url='<%= url_for(search_form: { facet => (params[:search_form][facet] + [result.value])}.reverse_merge(params[:search_form])) %>' value='<%= result.value.to_s %>'><%= label %></option>
+            <option data-facet-url='<%= url_for(search_form: { facet => (@search_params[facet] + [result.value])}.reverse_merge(@search_params)) %>' value='<%= result.value.to_s %>'><%= label %></option>
            <% end %>
         <% end %>
       <% end %>
@@ -33,14 +33,14 @@
               <% if (attribute.present? && result.instance.present?) %>
                 <% label = result.instance.send(attribute.to_sym) %>
                 <%= link_to((label.present? ? label : "unknown" ) + " (#{result.count})",
-                    url_for(:search_form => { facet => (params[:search_form][facet] + [result.value]) }.reverse_merge(params[:search_form]))) %>
+                    url_for(:search_form => { facet => (@search_params[facet] + [result.value]) }.reverse_merge(@search_params))) %>
               <% else %>
                 <%= link_to "#{result.value} (#{result.count})",
-                    url_for(:search_form => { facet => (params[:search_form][facet] + [result.value]) }.reverse_merge(params[:search_form]))%>
+                    url_for(:search_form => { facet => (@search_params[facet] + [result.value]) }.reverse_merge(@search_params))%>
               <% end %>
-              <% if params[:search_form][facet].present? && result.value.to_s.in?(params[:search_form][facet]) %>
+              <% if @search_params[facet].present? && result.value.to_s.in?(@search_params[facet]) %>
                 <%= link_to t("redsun.facet.remove"),
-                            url_for(search_form: { facet.to_sym => (params[:search_form][facet] - [result.value.to_s]) }.reverse_merge(params[:search_form]) ),
+                            url_for(search_form: { facet.to_sym => (@search_params[facet] - [result.value.to_s]) }.reverse_merge(@search_params) ),
                             class: "remove"  %>
               <% end %>
             </li>

--- a/app/views/redsun_search/index.html.erb
+++ b/app/views/redsun_search/index.html.erb
@@ -218,20 +218,20 @@
         tracker_id
         class_name
      ).each do |facet|
-    if params[:search_form][facet].present?
-      if params[:search_form][facet].is_a?(Array) %>
-        <% params[:search_form][facet].each do |facet_value| %>
+    if @search_params[facet].present?
+      if @search_params[facet].is_a?(Array) %>
+        <% @search_params[facet].each do |facet_value| %>
           <%= hidden_field_tag("search_form[#{facet}][]", facet_value) %>
         <% end %>
       <% else %>
-        <%= hidden_field_tag("search_form[#{facet}][]", params[:search_form][facet]) %>
+        <%= hidden_field_tag("search_form[#{facet}][]", @search_params[facet]) %>
       <% end %>
     <% end %>
   <% end %>
   <%= f.submit t('redsun.search_button'), class: 'redsun-search-button' %>
   <%= link_to t('redsun.reset'), url_for(controller: 'redsun_search', action: :index, project_id: params[:project_id]) %>
-  <%= f.hidden_field(:created_on, value: params[:search_form][:created_on]) if params[:search_form][:created_on].present? %>
-  <%= f.hidden_field(:updated_on, value: params[:search_form][:updated_on]) if params[:search_form][:updated_on].present? %>
+  <%= f.hidden_field(:created_on, value: @search_params[:created_on]) if @search_params[:created_on].present? %>
+  <%= f.hidden_field(:updated_on, value: @search_params[:updated_on]) if @search_params[:updated_on].present? %>
   <%= image_tag 'RedSun_Logo_red_on_white.svg', plugin: 'redmine_redsun', class: 'redsun-logo' %>
   <div class='redsun-hints'>
     <%=t('redsun.hints')%>
@@ -246,7 +246,7 @@
     <p>
       <strong><%= t('redsun.spellcheck_question') %></strong>
       <% @search.spellcheck_suggestions.first.last["suggestion"].each do |suggestion| %>
-        <%= link_to suggestion["word"], url_for(search_form: { searchstring: suggestion["word"] }.reverse_merge(params[:search_form])) %>
+        <%= link_to suggestion["word"], url_for(search_form: { searchstring: suggestion["word"] }.reverse_merge(@search_params)) %>
       <% end %>
     </p>
   <% end %>

--- a/lib/redmine_redsun/search_controller_patch.rb
+++ b/lib/redmine_redsun/search_controller_patch.rb
@@ -10,7 +10,7 @@ module RedmineRedsun
       # Same as typing in the class
       base.class_eval do
         unloadable # Send unloadable so it will not be unloaded in development
-        before_filter :pick_search_engine
+        before_action :pick_search_engine
       end
     end
     # :nodoc:


### PR DESCRIPTION
Rails 5 removed some deprecated APIs. This PR addresses that by converting them to supported ones. Especially:

* [strong parameters](https://guides.rubyonrails.org/action_controller_overview.html#strong-parameters)
* [before_filter became before_action](https://guides.rubyonrails.org/action_controller_overview.html#filters)