### PR TITLE
Switch to query-time boosting to support Solr 7 and better

### DIFF
--- a/app/controllers/redsun_search_controller.rb
+++ b/app/controllers/redsun_search_controller.rb
@@ -54,6 +54,16 @@ class RedsunSearchController < ApplicationController
         highlight :id
         highlight :title
         highlight :filename
+        boost_fields(
+          :filename => 9,
+          :subject => 9,
+          :description => 7,
+          :comments => 9,
+          :notes => 9,
+          :project_name => 10,
+          :title => 10,
+          :wiki_content => 8,
+        )
       end
 
       any_of do

--- a/lib/redmine_redsun/attachment_patch.rb
+++ b/lib/redmine_redsun/attachment_patch.rb
@@ -34,7 +34,7 @@ module RedmineRedsun
           end
 
           # Filename
-          text :filename, stored: true, boost: 9 do
+          text :filename, stored: true do
             filename.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join if filename.present?
           end
 

--- a/lib/redmine_redsun/issue_patch.rb
+++ b/lib/redmine_redsun/issue_patch.rb
@@ -31,12 +31,12 @@ module RedmineRedsun
           boolean :is_private, stored: true
 
           # Subject
-          text :subject, stored: true, boost: 9 do
+          text :subject, stored: true do
             subject.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join if subject.present?
           end
 
           # Description
-          text :description, stored: true, boost: 7 do
+          text :description, stored: true do
             description.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join if description.present?
           end
 
@@ -44,7 +44,7 @@ module RedmineRedsun
           integer :project_id
 
           # Journals entries, i.e. status updates, comments, etc.
-          text :comments, stored: true, boost: 9 do
+          text :comments, stored: true do
             journals.where("journals.notes != ''").map { |j| j.notes.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join if j.notes.present? }.join(' ')
           end
 

--- a/lib/redmine_redsun/journal_patch.rb
+++ b/lib/redmine_redsun/journal_patch.rb
@@ -28,7 +28,7 @@ module RedmineRedsun
           end
 
           # Notes
-          text :notes, stored: true, boost: 9 do
+          text :notes, stored: true do
             notes.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join if notes.present?
           end
 

--- a/lib/redmine_redsun/project_patch.rb
+++ b/lib/redmine_redsun/project_patch.rb
@@ -37,7 +37,7 @@ module RedmineRedsun
           end
 
           # Name of Project
-          text :project_name, stored: true, boost: 10 do
+          text :project_name, stored: true do
             name.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join if name.present?
           end
         end

--- a/lib/redmine_redsun/wiki_page_patch.rb
+++ b/lib/redmine_redsun/wiki_page_patch.rb
@@ -27,12 +27,12 @@ module RedmineRedsun
           end
 
           # Page Title
-          text :title, stored: true, boost: 10 do
+          text :title, stored: true do
             title.gsub(/[[:cntrl:]]/, ' ').gsub(/_/, ' ').scan(/[[:print:][:space:]]/).join
           end
 
           # Content of Page
-          text :wiki_content, stored: true, boost: 8 do
+          text :wiki_content, stored: true do
             content.text.gsub(/[[:cntrl:]]/, ' ').scan(/[[:print:][:space:]]/).join unless content.nil?
           end
 


### PR DESCRIPTION
Solr 7 dropped support for index-time boosting. From the [changelog](https://lucene.apache.org/solr/guide/7_7/major-changes-in-solr-7.html):

> Index-time boosts have been removed from Lucene, and are no longer available from Solr. If any boosts are provided, they will be ignored by the indexing chain. As a replacement, index-time scoring factors should be indexed in a separate field and combined with the query score using a function query. See the section Function Queries for more information.

Let's use query time boosting instead (and maybe make that configurable in the plugin settings in a second PR).