### PR TITLE
PoC: Add support for indexing the content of attachments using sunspot_cell

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 gem 'sunspot_rails', '2.5.0'
+gem 'sunspot_cell', :git => "https://github.com/waterfield/sunspot_cell.git", :branch => "2.3.0"
 gem 'will_paginate', '~> 3.1.3'
 
 group :development do

--- a/lib/redmine_redsun/attachment_patch.rb
+++ b/lib/redmine_redsun/attachment_patch.rb
@@ -52,6 +52,8 @@ module RedmineRedsun
           # Name of Project
           string :project_name, stored: true
 
+          # Content
+          attachment :diskfile
         end
       end
     end


### PR DESCRIPTION
This PR adds support for text extraction of binary attachments using [tika](https://lucene.apache.org/solr/guide/7_7/uploading-data-with-solr-cell-using-apache-tika.html). Regrettably there is currently no centrally maintained version of `sunspot_cell`. The [waterfield fork](https://github.com/waterfield/sunspot_cell/) seems to be the most advanced one.

It is currently necessary to use `xml` as the sunspot `update_format`. The json format can be fixed with waterfield/sunspot_cell#1

The following `config/sunspot.yml` is working for me:

```yaml
---
development:
  solr:
    hostname: localhost
    port: 8983
    log_level: INFO
    path: /solr/sunspot
    solr_home: solr
    update_format: xml
```

I'm using [docker solr 7](https://hub.docker.com/_/solr) for testing purposes with the core config from the sunspot [examples](/sunspot/sunspot/tree/master/examples/solr7_core/conf) with libs, fields, fieldTypes and ExtractingRequestHandler added (see attached [sunspot-configset_cell.patch.txt](https://github.com/dkd/redsun/files/5542329/sunspot-configset_cell.patch.txt)).

This PR is in a proof-of-concept stage. The necessary config changes could be incorporated into the included solr config example. Also it would be nice if the search result would display a result snipped and not only the attachment...
